### PR TITLE
Fix trace_requests() argument name in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -463,7 +463,7 @@ For tracing `requests <https://github.com/requests/requests>`_ client library fo
     # undesireable so it's also possible to avoid tracing specific URL's or
     # endpoints. trace_requests accepts a list of regex patterns and matches the
     # request.url against these patterns, ignoring traces if any pattern matches.
-    # trace_requests(ignore_patterns=[r".*hostname/endpoint"]
+    # trace_requests(ignore_url_patterns=[r".*hostname/endpoint"])
 
     import requests
 


### PR DESCRIPTION
The argument accepted by `trace_requests()` is called `ignore_url_patterns`, not `ignore_patterns`.